### PR TITLE
Remove alerts and netscape.security.PrivilegeManager

### DIFF
--- a/src/stackblur.js
+++ b/src/stackblur.js
@@ -126,21 +126,10 @@ function getImageDataFromCanvas(canvas, top_x, top_y, width, height)
         try {
             imageData = context.getImageData(top_x, top_y, width, height);
         } catch(e) {
-
-            // NOTE: this part is supposedly only needed if you want to work with local files
-            // so it might be okay to remove the whole try/catch block and just use
-            // imageData = context.getImageData(top_x, top_y, width, height);
-            try {
-                netscape.security.PrivilegeManager.enablePrivilege("UniversalBrowserRead");
-                imageData = context.getImageData(top_x, top_y, width, height);
-            } catch(e) {
-                alert("Cannot access local image");
-                throw new Error("unable to access local image data: " + e);
-                return;
-            }
+            throw new Error("unable to access local image data: " + e);
+            return;
         }
     } catch(e) {
-        alert("Cannot access image");
         throw new Error("unable to access image data: " + e);
     }
 


### PR DESCRIPTION
Hey @flozz,

Thank you for maintaining this repo. I noticed a few things in the code and thought I'd send you a pull request:

So, according to [this site](https://www.fxsitecompat.com/en-CA/docs/2012/privilege-manager-has-been-disabled/) and [this](https://bugzilla.mozilla.org/show_bug.cgi?id=546848) bug report, the ``netscape.security.PrivilegeManager`` has been disabled since Firefox 17.

The patch removes the try-catch statement that was calling ``netscape.security.PrivilegeManager`` as well as two ``alert()`` calls.

Please let me know if you have questions about the code.

Have a great day!