### PR TITLE
Remove dist file from npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
-dist
 demo.html
 bower.json
 Gruntfile.js


### PR DESCRIPTION
Now NPM is being used for frontend packages it is useful to have compiled versions included.